### PR TITLE
Prepare Pika for MooseVariable::sln() const update.

### DIFF
--- a/include/auxkernels/PikaSupersaturation.h
+++ b/include/auxkernels/PikaSupersaturation.h
@@ -55,10 +55,10 @@ protected:
 private:
 
   /// Chemical potential variable
-  VariableValue & _s;
+  const VariableValue & _s;
 
   /// Temperature variable
-  VariableValue & _temperature;
+  const VariableValue & _temperature;
 
   /// Density of ice
   const Real & _rho_i;

--- a/include/bcs/PikaChemicalPotentialBC.h
+++ b/include/bcs/PikaChemicalPotentialBC.h
@@ -46,10 +46,10 @@ protected:
 private:
 
   /// Coupled temperature variable
-  VariableValue & _temperature;
+  const VariableValue & _temperature;
 
   /// Coupled phase-field variable
-  VariableValue & _phase;
+  const VariableValue & _phase;
 };
 
 #endif // PIKACHEMICALPOTENTIALBC_H

--- a/include/ics/PikaChemicalPotentialIC.h
+++ b/include/ics/PikaChemicalPotentialIC.h
@@ -41,10 +41,10 @@ protected:
 private:
 
   /// The coupled temperature variable
-  VariableValue & _temperature;
+  const VariableValue & _temperature;
 
   /// The coupled phase-field variable
-  VariableValue & _phase;
+  const VariableValue & _phase;
 };
 
 #endif // PIKACHEMICALPOTENTIALIC_H

--- a/include/kernels/PhaseTransition.h
+++ b/include/kernels/PhaseTransition.h
@@ -36,11 +36,11 @@ protected:
   virtual Real computeDFDOP(PFFunctionType type);
 
 private:
-  VariableValue & _s;
+  const VariableValue & _s;
 
   const MaterialProperty<Real> & _lambda;
 
   const MaterialProperty<Real> & _s_eq;
-
 };
+
 #endif // PHASETRANSITION_H

--- a/include/materials/PikaMaterial.h
+++ b/include/materials/PikaMaterial.h
@@ -45,10 +45,10 @@ private:
   bool _debug;
 
   /// Coupled temperature variable
-  VariableValue & _temperature;
+  const VariableValue & _temperature;
 
   /// Coupled phase-field variable
-  VariableValue & _phase;
+  const VariableValue & _phase;
 
   /// Interface thickness, W
   const Real & _interface_thickness;

--- a/include/materials/TensorMobilityMaterial.h
+++ b/include/materials/TensorMobilityMaterial.h
@@ -48,7 +48,7 @@ private:
 
   const RealTensorValue _identity;
 
-  VariableValue & _phase;
+  const VariableValue & _phase;
 
   VariableGradient & _grad_phase;
 
@@ -59,10 +59,6 @@ private:
   MaterialProperty<Real> & _M_parallel;
   MaterialProperty<Real> & _M_perpendicular;
   MaterialProperty<RealTensorValue> & _M_tensor;
-
-
-
-
 };
 
 #endif //TENSORMOBILITYMATERIAL_H


### PR DESCRIPTION
This set of changes prepares Pika to work with an upcoming version of
MOOSE in which MooseVariable::sln() returns a const reference.

Refs idaholab/moose#6327.