### PR TITLE
Prepare Pika for coupledGradient() const reference return value.

### DIFF
--- a/include/auxkernels/PikaInterfaceVelocity.h
+++ b/include/auxkernels/PikaInterfaceVelocity.h
@@ -56,11 +56,10 @@ private:
   const Real & _D_v;
 
   /// Gradient of the phase-field variable
-  VariableGradient & _grad_phase;
+  const VariableGradient & _grad_phase;
 
   /// Gradient of the chemical potential variable
-  VariableGradient & _grad_s;
-
+  const VariableGradient & _grad_s;
 };
 
 #endif //PIKAINTERFACEVELOCITY_H

--- a/include/materials/TensorMobilityMaterial.h
+++ b/include/materials/TensorMobilityMaterial.h
@@ -50,7 +50,7 @@ private:
 
   const VariableValue & _phase;
 
-  VariableGradient & _grad_phase;
+  const VariableGradient & _grad_phase;
 
   //
   const Real & _M_1;


### PR DESCRIPTION
This set of changes prepares Pika to work with an upcoming version of
MOOSE in which coupledGradient() returns a const reference.

Refs idaholab/moose#6327.