### PR TITLE
libMesh::TypeVector::size() and size_sq() have been deprecated.

### DIFF
--- a/src/auxkernels/PikaInterfaceVelocity.C
+++ b/src/auxkernels/PikaInterfaceVelocity.C
@@ -37,7 +37,7 @@ Real
 PikaInterfaceVelocity::computeValue()
 {
   // Compute the normal vector
-  RealGradient n = _grad_phase[_qp] / _grad_phase[_qp].size();
+  RealGradient n = _grad_phase[_qp] / _grad_phase[_qp].norm();
 
   // Return the velocity (Eq. 23)
   return _D_v * n * _grad_s[_qp];

--- a/src/kernels/AntiTrapping.C
+++ b/src/kernels/AntiTrapping.C
@@ -32,7 +32,7 @@ AntiTrapping::AntiTrapping(const InputParameters & parameters) :
 Real
 AntiTrapping::computeQpResidual()
 {
-  RealGradient n = _grad_phase[_qp] / _grad_phase[_qp].size();
+  RealGradient n = _grad_phase[_qp] / _grad_phase[_qp].norm();
   return -(1.0/(2.0 * std::pow(2.0,0.5))) * n * _w * _phase_dot[_qp] * _grad_test[_i][_qp];
 }
 

--- a/src/materials/TensorMobilityMaterial.C
+++ b/src/materials/TensorMobilityMaterial.C
@@ -59,7 +59,7 @@ RealTensorValue
 TensorMobilityMaterial::normalOutputProduct()
 {
 
-  RealVectorValue n = _grad_phase[_qp] / _grad_phase[_qp].size();
+  RealVectorValue n = _grad_phase[_qp] / _grad_phase[_qp].norm();
   RealTensorValue nxn;
 
   for (unsigned int i = 0; i < LIBMESH_DIM; ++i)


### PR DESCRIPTION
They are replaced by norm() and norm_sq(), respectively.

Refs libMesh/libmesh#829.