### PR TITLE
add missing parameters to validParams funcs

### DIFF
--- a/src/materials/PikaMaterial.C
+++ b/src/materials/PikaMaterial.C
@@ -23,6 +23,9 @@ InputParameters validParams<PikaMaterial>()
   params.addRequiredCoupledVar("phase", "The phase-field variable");
   params.addParam<bool>("debug", false, "Enable the creating of material properties for debugging");
 
+  params.addParam<std::vector<OutputName> >("outputs", std::vector<OutputName>(1, "none"), "Vector of output names were you would like to restrict the output of material data (empty outputs to all)");
+  params.addParam<std::vector<std::string> >("output_properties", std::vector<std::string>(), "List of material properties, from this material, to output (outputs must also be defined to an output type)");
+
   return params;
 }
 

--- a/src/userobjects/PropertyUserObject.C
+++ b/src/userobjects/PropertyUserObject.C
@@ -19,6 +19,8 @@ InputParameters validParams<PropertyUserObject>()
   InputParameters params = validParams<GeneralUserObject>();
   params += PropertyUserObject::objectParams();
   params.suppressParameter<ExecFlagEnum>("execute_on");
+  params.addParam<std::vector<OutputName> >("outputs", std::vector<OutputName>(1, "none"), "Vector of output names were you would like to restrict the output of material data (empty outputs to all)");
+  params.addParam<std::vector<std::string> >("output_properties", std::vector<std::string>(), "List of material properties, from this material, to output (outputs must also be defined to an output type)");
   return params;
 }
 


### PR DESCRIPTION
An upcoming moose PR (idaholab/moose#10547) will require all parameters
that are set/read to be declared in validParams.  This makes pika
compliant with that requirement.