### PR TITLE
Fixing "MeshModifiers" error in input files of problems/snow_2d/

### DIFF
--- a/problems/snow_2d/phi_initial.i
+++ b/problems/snow_2d/phi_initial.i
@@ -8,9 +8,6 @@
   ymax = .005
 []
 
-[MeshModifiers]
-[]
-
 [Variables]
   [./phi]
   [../]

--- a/problems/snow_2d/phi_initial_small.i
+++ b/problems/snow_2d/phi_initial_small.i
@@ -8,9 +8,6 @@
   ymax = .005
 []
 
-[MeshModifiers]
-[]
-
 [Variables]
   [./phi]
   [../]


### PR DESCRIPTION
Dear Developer,

I was testing some examples and there was an error of "[MeshModifiers]", which were blank so I have removed it. Perhaps its a deprecated class or something still under development. Anyhow, as the block was empty there should not be any impact on the result. So would you please accept the pull request to make these changes in the default branch.