### PR TITLE
Remove unused parameters. 

### DIFF
--- a/tests/mass_transport/mms/mms_mass_transport_steady.i
+++ b/tests/mass_transport/mms/mms_mass_transport_steady.i
@@ -84,7 +84,6 @@
   [../]
   [./hmax]
     type = AverageElementSize
-    variable = u
     execute_on = 'initial timestep_end'
   [../]
 []

--- a/tests/mass_transport/mms/mms_mass_transport_transient_dphi_dt_first.i
+++ b/tests/mass_transport/mms/mms_mass_transport_transient_dphi_dt_first.i
@@ -99,7 +99,6 @@
   [../]
   [./hmax]
     type = AverageElementSize
-    variable = u
     execute_on = 'initial timestep_end'
   [../]
   [./L2_norm]

--- a/tests/mass_transport/mms/mms_mass_transport_transient_dphi_dt_second.i
+++ b/tests/mass_transport/mms/mms_mass_transport_transient_dphi_dt_second.i
@@ -110,7 +110,6 @@
   [../]
   [./hmax]
     type = AverageElementSize
-    variable = u
     execute_on = 'initial timestep_end'
   [../]
   [./L2_norm]

--- a/tests/mass_transport/mms/mms_mass_transport_transient_first.i
+++ b/tests/mass_transport/mms/mms_mass_transport_transient_first.i
@@ -83,7 +83,6 @@
   [../]
   [./hmax]
     type = AverageElementSize
-    variable = u
     execute_on = 'initial timestep_end'
   [../]
   [./L2_norm]

--- a/tests/mass_transport/mms/mms_mass_transport_transient_second.i
+++ b/tests/mass_transport/mms/mms_mass_transport_transient_second.i
@@ -85,7 +85,6 @@
   [../]
   [./hmax]
     type = AverageElementSize
-    variable = u
     execute_on = 'initial timestep_end'
   [../]
   [./L2_norm]


### PR DESCRIPTION
Removing unused parameters as they will throw errors following a new MOOSE update. Closes #156 -- view that Issue for more info